### PR TITLE
Bradjohnl hotfix chrome instance crash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,21 @@
 FROM node:17
 
-RUN apt-get update && apt-get install -y net-tools iproute2 ca-certificates wget gnupg --no-install-recommends
-
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
-      --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./package.json /srv
-COPY ./index.js /srv
-
 WORKDIR /srv
-RUN npm install pm2 -g
-RUN npm install
 
-#block access to AWS metadata IP before starting server
-CMD ip route add blackhole 169.254.169.254; pm2-runtime index.js
+COPY ./package.json .
+COPY ./index.js .
+COPY entrypoint.sh .
+
+RUN apt-get update && apt-get install -y net-tools iproute2 ca-certificates wget gnupg --no-install-recommends &&\
+    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list &&\
+    apt-get update &&\
+    apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf --no-install-recommends &&\
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/* &&\
+    npm install pm2 -g &&\
+    npm install &&\
+    chmod +x entrypoint.sh 
+
+CMD ["./entrypoint.sh"]
 
 EXPOSE $PORT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 --hide-scrollbars --blink-settings=imagesEnabled=false --no-sandbox --disable-dev-shm-usage &
+#block access to AWS metadata IP before starting server
+ip route add blackhole 169.254.169.254
+pm2-runtime index.js


### PR DESCRIPTION
This workaround fixes the production issue that renders the prerender service unavailable due to the chrome instance crashing when ran inside the container.

This fix is not indended to be permanent as it's quite hacky, but it will buy us time to implement a more robust solution while ensuring the service continuity.