### PR TITLE
MODIFIED: replace origin.* references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+node_modules

--- a/index.js
+++ b/index.js
@@ -103,8 +103,10 @@ class RenderService {
   }
 
   sendHtmlResponse(html, response) {
+    // replace origin.casper.network references
+    const output = (html || '').replace(/origin\.casper\.network/gm, 'casper.network');
     response.writeHead(200, { 'Content-Type': 'text/html; charset=UTF-8' });
-    response.end(html);
+    response.end(output);
   }
 
   sendHttpStatus(status, headers, response) {


### PR DESCRIPTION
- replace any `origin.casper.network` references in the resulting output with `casper.network`
- also added .gitignore